### PR TITLE
scheduler: auto-detect LINSTOR API endpoint

### DIFF
--- a/charts/linstor-scheduler/Chart.yaml
+++ b/charts/linstor-scheduler/Chart.yaml
@@ -16,5 +16,5 @@ home: https://github.com/piraeusdatastore/helm-charts
 sources:
   - https://github.com/piraeusdatastore/linstor-scheduler-extender
 
-version: 0.1.1
+version: 0.1.2
 appVersion: "v0.2.1"

--- a/charts/linstor-scheduler/README.md
+++ b/charts/linstor-scheduler/README.md
@@ -11,14 +11,8 @@ Volume they might use. This works for any setup using LINSTOR, i.e. Piraeus Data
 The scheduler is meant to be installed in the same namespace as LINSTOR itself, otherwise additional steps may be
 required.
 
-First, you need to determine the LINSTOR Controllers' Service URL. Typically, this is:
-
-* `http://piraeus-op-cs.<namespace>.svc:3370`
-* `http://linstor-op-cs.<namespace>.svc:3370`
-
-If you use TLS, use `https://` instead of `http://` and `3371` instead of `3370`. Also note the name of
-the `*-client-secret`
-used by LINSTOR API clients to connect to the API when using TLS.
+If installed along side Piraeus Operator, the LINSTOR endpoint is determined automatically. Otherwise, you need
+to set `linstor.endpoint` and `linstor.clientSecret` values as appropriate.
 
 The following command will install the scheduler for a typical Piraeus Data-Store configuration with TLS enabled:
 
@@ -48,8 +42,8 @@ The following options are available:
 | Option                                        | Usage                                                                                                  | Default                                                                                            |
 |-----------------------------------------------|--------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
 | `replicaCount`                                | Number of replicas to deploy.                                                                          | `1`                                                                                                |
-| `linstorEndpoint`                             | URL of the LINSTOR Controller API.                                                                     | `""`                                                                                               |
-| `linstorClientSecret`                         | TLS secret to use to authenticate with the LINSTOR API                                                 | `""`                                                                                               |
+| `linstor.endpoint`                            | URL of the LINSTOR Controller API.                                                                     | `""`                                                                                               |
+| `linstor.clientSecret`                        | TLS secret to use to authenticate with the LINSTOR API                                                 | `""`                                                                                               |
 | `extender.image.repository`                   | Repository to pull the linstor-scheduler-extender image from.                                          | `quay.io/piraeusdatastore/linstor-scheduler-extender`                                              |
 | `extender.image.pullPolicy`                   | Pull policy to use. Possible values: `IfNotPresent`, `Always`, `Never`                                 | `IfNotPresent`                                                                                     |
 | `extender.image.tag`                          | Override the tag to pull. If not given, defaults to charts `AppVersion`.                               | `""`                                                                                               |

--- a/charts/linstor-scheduler/templates/NOTES.txt
+++ b/charts/linstor-scheduler/templates/NOTES.txt
@@ -1,5 +1,7 @@
 Scheduler {{ include "linstor-scheduler.fullname" . }} deployed!
 
+Used LINSTOR URL: {{ include "linstor-scheduler.linstorEndpoint" .}}
+
 Please run `helm test {{ .Release.Name }}` to ensure it's properly working.
 
 Specify the scheduler on your pods to start smart scheduling based on your Persistent Volumes:

--- a/charts/linstor-scheduler/templates/_helpers.tpl
+++ b/charts/linstor-scheduler/templates/_helpers.tpl
@@ -67,3 +67,75 @@ Get the kubernetes version we should assume for creating scheduler configs
 {{- define "linstor-scheduler.kubeVersion" }}
 {{- .Values.scheduler.image.compatibleKubernetesRelease | default .Capabilities.KubeVersion.Version }}
 {{- end }}
+
+{{/*
+Find the linstor client secret containing TLS certificates
+*/}}
+{{- define "linstor-scheduler.linstorClientSecretName" -}}
+{{- if .Values.linstor.clientSecret }}
+{{- .Values.linstor.clientSecret }}
+{{- else if .Capabilities.APIVersions.Has "piraeus.linbit.com/v1/LinstorController" }}
+{{- $crs := (lookup "piraeus.linbit.com/v1" "LinstorController" .Release.Namespace "").items }}
+{{- if $crs }}
+{{- if eq (len $crs) 1 }}
+{{- $item := index $crs 0 }}
+{{- $item.spec.linstorHttpsClientSecret }}
+{{- end }}
+{{- end }}
+{{- else if .Capabilities.APIVersions.Has "linstor.linbit.com/v1/LinstorController" }}
+{{- $crs := (lookup "linstor.linbit.com/v1" "LinstorController" .Release.Namespace "").items }}
+{{- if $crs }}
+{{- if eq (len $crs) 1 }}
+{{- $item := index $crs 0 }}
+{{- $item.spec.linstorHttpsClientSecret }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Find the linstor URL by operator resources
+*/}}
+{{- define "linstor-scheduler.linstorEndpointFromCRD" -}}
+{{- if .Capabilities.APIVersions.Has "piraeus.linbit.com/v1/LinstorController" }}
+{{- $crs := (lookup "piraeus.linbit.com/v1" "LinstorController" .Release.Namespace "").items }}
+{{- if $crs }}
+{{- if eq (len $crs) 1 }}
+{{- $item := index $crs 0 }}
+{{- if include "linstor-scheduler.linstorClientSecretName" . }}
+{{- printf "https://%s.%s.svc:3371" $item.metadata.name $item.metadata.namespace }}
+{{- else }}
+{{- printf "http://%s.%s.svc:3370" $item.metadata.name $item.metadata.namespace }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- else if .Capabilities.APIVersions.Has "linstor.linbit.com/v1/LinstorController" }}
+{{- $crs := (lookup "linstor.linbit.com/v1" "LinstorController" .Release.Namespace "").items }}
+{{- if $crs }}
+{{- if eq (len $crs) 1 }}
+{{- $item := index $crs 0 }}
+{{- if include "linstor-scheduler.linstorClientSecretName" . }}
+{{- printf "https://%s.%s.svc:3371" $item.metadata.name $item.metadata.namespace }}
+{{- else }}
+{{- printf "http://%s.%s.svc:3370" $item.metadata.name $item.metadata.namespace }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Find the linstor URL either by override or cluster resources
+*/}}
+{{- define "linstor-scheduler.linstorEndpoint" -}}
+{{- if .Values.linstor.endpoint }}
+{{- .Values.linstor.endpoint }}
+{{- else }}
+{{- $piraeus := include "linstor-scheduler.linstorEndpointFromCRD" . }}
+{{- if $piraeus }}
+{{- $piraeus }}
+{{- else }}
+{{- fail "Please specify linstor.endpoint, no default URL could be determined" }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/linstor-scheduler/templates/deployment.yaml
+++ b/charts/linstor-scheduler/templates/deployment.yaml
@@ -88,22 +88,22 @@ spec:
             - --verbose=true
           env:
             - name: LS_CONTROLLERS
-              value: {{ .Values.linstorEndpoint }}
-            {{- if .Values.linstorClientSecret }}
+              value: {{ include "linstor-scheduler.linstorEndpoint" . }}
+            {{- if include "linstor-scheduler.linstorClientSecretName" . }}
             - name: LS_USER_CERTIFICATE
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.linstorClientSecret }}
+                  name: {{ include "linstor-scheduler.linstorClientSecretName" . }}
                   key: tls.crt
             - name: LS_USER_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.linstorClientSecret }}
+                  name: {{ include "linstor-scheduler.linstorClientSecretName" . }}
                   key: tls.key
             - name: LS_ROOT_CA
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.linstorClientSecret }}
+                  name: {{ include "linstor-scheduler.linstorClientSecretName" . }}
                   key: ca.crt
             {{- end }}
       {{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.Version }}

--- a/charts/linstor-scheduler/values.yaml
+++ b/charts/linstor-scheduler/values.yaml
@@ -1,7 +1,8 @@
 replicaCount: 1
 
-linstorEndpoint: ""
-linstorClientSecret: ""
+linstor:
+  endpoint: ""
+  clientSecret: ""
 
 scheduler:
   args: []


### PR DESCRIPTION
Use Piraeus or LINSTOR Operator resources to determine LINSTOR url
and connection secrets if present. Otherwise fall back to user-provided values
or complain to the user if non are present.