### PR TITLE
fix: Add VolumeSnapshotClass in the validatingWebhook resource list

### DIFF
--- a/charts/snapshot-validation-webhook/Chart.yaml
+++ b/charts/snapshot-validation-webhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: snapshot-validation-webhook
-version: 1.7.2
+version: 1.7.3
 appVersion: "v6.2.2"
 icon: https://raw.githubusercontent.com/piraeusdatastore/piraeus/master/artwork/sandbox-artwork/icon/color.svg
 maintainers:

--- a/charts/snapshot-validation-webhook/templates/webhook.yaml
+++ b/charts/snapshot-validation-webhook/templates/webhook.yaml
@@ -68,6 +68,7 @@ webhooks:
         - UPDATE
         resources:
         - volumesnapshots
+        - volumesnapshotclasses
         - volumesnapshotcontents
         scope: "*"
     clientConfig:


### PR DESCRIPTION
Without this, it will not guarantee only one default vsclass for one provider.
