### PR TITLE
change leader election check to use correct value

### DIFF
--- a/charts/linstor-affinity-controller/Chart.yaml
+++ b/charts/linstor-affinity-controller/Chart.yaml
@@ -14,5 +14,5 @@ home: https://github.com/piraeusdatastore/helm-charts
 sources:
   - https://github.com/piraeusdatastore/linstor-affinity-controller
 
-version: 1.2.0
+version: 1.2.1
 appVersion: "v0.3.0"

--- a/charts/linstor-affinity-controller/templates/rbac.yaml
+++ b/charts/linstor-affinity-controller/templates/rbac.yaml
@@ -55,7 +55,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "linstor-affinity-controller.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-{{- if get .Values.options "leader-election" }}
+{{- if .Values.options.leaderElection }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
In rbac.yaml of the linstor-affinity-controller chart I found that the options.leaderElection check was using "leader-election" instead of leaderElection. This caused it to never render the templates for Role and RoleBinding.