### PR TITLE
fix: Add revisionHistoryLimit override

### DIFF
--- a/charts/snapshot-controller/README.md
+++ b/charts/snapshot-controller/README.md
@@ -44,7 +44,7 @@ kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-sna
 ## Upgrade from older CRDs
 
 In an effort to tighten validation, the CSI project started enforcing stricter requirements on `VolumeSnapshot` and
-`VolumeSnapshotContent` resources when switching from `v1beta1` to `v1` CRDs. This validation webhook is part of 
+`VolumeSnapshotContent` resources when switching from `v1beta1` to `v1` CRDs. This validation webhook is part of
 enforcing these requirements. When upgrading you [have to ensure non of your resources violate the requirements for `v1`].
 
 The upgrade procedure can be summarized by the following steps:
@@ -88,6 +88,7 @@ The following options are available:
 | `controller.enabled`                     | Toggle to disable the deployment of the snapshot controller.                                                           | `true`                                                                                             |
 | `controller.args`                        | Arguments to pass to the snapshot controller. Note: Keys will be converted to kebab-case, i.e. `oneArg` -> `--one-arg` | `...`                                                                                              |
 | `controller.replicaCount`                | Number of replicas to deploy.                                                                                          | `1`                                                                                                |
+| `controller.revisionHistoryLimit`        | Number of revisions to keep.                                                                                           | `10`                                                                                               |
 | `controller.image.repository`            | Repository to pull the image from.                                                                                     | `registry.k8s.io/sig-storage/snapshot-controller`                                                  |
 | `controller.image.pullPolicy`            | Pull policy to use. Possible values: `IfNotPresent`, `Always`, `Never`                                                 | `IfNotPresent`                                                                                     |
 | `controller.image.tag`                   | Override the tag to pull. If not given, defaults to charts `AppVersion`.                                               | `""`                                                                                               |
@@ -141,6 +142,7 @@ available.
 | `webhook.enabled`                            | Toggle to disable the deployment of the snapshot validation webhook.                                                   | `true`                                                                                             |
 | `webhook.args`                               | Arguments to pass to the snapshot controller. Note: Keys will be converted to kebab-case, i.e. `oneArg` -> `--one-arg` | `...`                                                                                              |
 | `webhook.replicaCount`                       | Number of replicas to deploy.                                                                                          | `1`                                                                                                |
+| `webhook.revisionHistoryLimit`               | Number of revisions to keep.                                                                                           | `10`                                                                                               |
 | `webhook.image.repository`                   | Repository to pull the image from.                                                                                     | `registry.k8s.io/sig-storage/snapshot-validation-webhook`                                          |
 | `webhook.image.pullPolicy`                   | Pull policy to use. Possible values: `IfNotPresent`, `Always`, `Never`                                                 | `IfNotPresent`                                                                                     |
 | `webhook.image.tag`                          | Override the tag to pull. If not given, defaults to charts `AppVersion`.                                               | `""`                                                                                               |

--- a/charts/snapshot-controller/templates/deployment_controller.yaml
+++ b/charts/snapshot-controller/templates/deployment_controller.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "snapshot-controller.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.controller.replicaCount }}
+  revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "snapshot-controller.selectorLabels" . | nindent 6 }}
@@ -70,4 +71,3 @@ spec:
       priorityClassName: {{ .Values.controller.priorityClassName }}
       {{- end }}
 {{- end }}
-

--- a/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
+++ b/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "snapshot-validation-webhook.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.webhook.replicaCount }}
+  revisionHistoryLimit: {{ .Values.webhook.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "snapshot-validation-webhook.selectorLabels" . | nindent 6 }}

--- a/charts/snapshot-controller/values.yaml
+++ b/charts/snapshot-controller/values.yaml
@@ -3,6 +3,8 @@ controller:
 
   replicaCount: 1
 
+  revisionHistoryLimit: 10
+
   args:
     leaderElection: true
     leaderElectionNamespace: "$(NAMESPACE)"
@@ -75,6 +77,8 @@ webhook:
   enabled: true
 
   replicaCount: 1
+
+  revisionHistoryLimit: 10
 
   args:
     tlsPrivateKeyFile: /etc/snapshot-validation/tls.key


### PR DESCRIPTION
Adds support for overriding the `revisionHistoryLimit` value on both Deployments. Default is set to 10 which is the implicit Kubernetes default.