### PR TITLE
snapshot-controller: upstream release 6.3.3

### DIFF
--- a/charts/snapshot-controller/Chart.yaml
+++ b/charts/snapshot-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: snapshot-controller
-version: 2.0.3
-appVersion: "v6.3.2"
+version: 2.0.4
+appVersion: "v6.3.3"
 icon: https://raw.githubusercontent.com/piraeusdatastore/piraeus/master/artwork/sandbox-artwork/icon/color.svg
 maintainers:
   - name: The Piraeus Maintainers


### PR DESCRIPTION
New external-snapshotter version contains an important fix to replaces the update calls for VolumeSnapshot and VolumeSnapshotContent with JSON patch calls. Addresses the "object has been modified" issue we see a lot in the snapshot-controller/snapshotter. See https://github.com/kubernetes-csi/external-snapshotter/pull/974.