### PR TITLE
ci: don't run oci steps if no charts were released

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,12 +36,14 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
+        id: cr
         with:
           skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Push Charts to GHCR
+      - if: ${{ steps.cr.outputs.changed_charts }}
+        name: Push Charts to GHCR
         run: |
           for pkg in .cr-release-packages/*; do
             if [ -z "${pkg:-}" ]; then


### PR DESCRIPTION
@WanzenBug here ya go.