### PR TITLE
snapshot-controller,linstor-cluster: add vgsclasses

### DIFF
--- a/charts/linstor-cluster/Chart.yaml
+++ b/charts/linstor-cluster/Chart.yaml
@@ -13,5 +13,5 @@ keywords:
   - storage
 sources:
   - https://github.com/piraeusdatastore/linstor-cluster
-version: 1.1.0
+version: 1.1.1
 appVersion: "v2.9.0"

--- a/charts/linstor-cluster/templates/volumegroupsnapshotclass.yaml
+++ b/charts/linstor-cluster/templates/volumegroupsnapshotclass.yaml
@@ -1,0 +1,22 @@
+{{- range .Values.volumeGroupSnapshotClasses }}
+---
+apiVersion: groupsnapshot.storage.k8s.io/v1beta1
+kind: VolumeGroupSnapshotClass
+metadata:
+  name: {{ .name }}
+{{- if .annotations }}
+  annotations:
+    {{- toYaml .annotations | nindent 4 }}
+{{- end }}
+  labels:
+    {{- include "linstor-cluster.labels" $ | nindent 4 }}
+{{- if .labels }}
+    {{- toYaml .labels | nindent 4 }}
+{{- end }}
+driver: {{ .driver | default "linstor.csi.linbit.com" }}
+deletionPolicy: {{ .deletionPolicy | default "Delete" }}
+{{- if .parameters }}
+parameters:
+  {{- toYaml .parameters | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/linstor-cluster/values.schema.json
+++ b/charts/linstor-cluster/values.schema.json
@@ -7,7 +7,8 @@
     "linstorNodeConnections",
     "monitoring",
     "storageClasses",
-    "volumeSnapshotClasses"
+    "volumeSnapshotClasses",
+    "volumeGroupSnapshotClasses"
   ],
   "properties": {
     "linstorCluster": {
@@ -184,6 +185,44 @@
       }
     },
     "volumeSnapshotClasses": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "annotations": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "deletionPolicy": {
+            "type": "string"
+          },
+          "driver": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "parameters": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "volumeGroupSnapshotClasses": {
       "type": "array",
       "items": {
         "type": "object",

--- a/charts/linstor-cluster/values.yaml
+++ b/charts/linstor-cluster/values.yaml
@@ -280,9 +280,9 @@ storageClasses: []
 volumeSnapshotClasses: []
 #  - name: linstor-snapshot1
 #    annotations:
-#      velero.io/csi-volumesnapshot-class: ""
+#      snapshot.storage.kubernetes.io/is-default-class: "true"
 #    labels:
-#      example.com/snapshot-class: "true"
+#      velero.io/csi-volumesnapshot-class: "true"
 #    driver: linstor.csi.linbit.com
 #    deletionPolicy: Delete
 #    parameters:
@@ -294,3 +294,15 @@ volumeSnapshotClasses: []
 #      snap.linstor.csi.linbit.com/s3-signing-region: example
 #      csi.storage.k8s.io/snapshotter-secret-name: linstor-csi-s3-access
 #      csi.storage.k8s.io/snapshotter-secret-namespace: piraeus-datastore
+
+# List of volumeGroupSnapshotClasses. You can create different vgsclasses with different parameters.
+volumeGroupSnapshotClasses: []
+#  - name: linstor-snapshot1
+#    annotations:
+#      groupsnapshot.storage.kubernetes.io/is-default-class: "true"
+#    labels:
+#      velero.io/csi-volumegroupsnapshot-class: "true"
+#    driver: linstor.csi.linbit.com
+#    deletionPolicy: Delete
+#    parameters:
+#      snap.linstor.csi.linbit.com/type: InCluster

--- a/charts/snapshot-controller/Chart.yaml
+++ b/charts/snapshot-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: snapshot-controller
-version: 4.1.0
+version: 4.1.1
 appVersion: "v8.3.0"
 kubeVersion: ">= 1.25.0-0"
 icon: https://raw.githubusercontent.com/piraeusdatastore/piraeus/master/artwork/sandbox-artwork/icon/color.svg

--- a/charts/snapshot-controller/README.md
+++ b/charts/snapshot-controller/README.md
@@ -33,9 +33,12 @@ helm upgrade snapshot-controller piraeus-charts/snapshot-controller
 To enjoy all the latest features of the snapshot controller, you may want to upgrade your CRDs as well:
 
 ```
-kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.2.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
-kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.2.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
-kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.2.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.3.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.3.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.3.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.3.0/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
+kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.3.0/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
+kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.3.0/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
 ```
 
 ## Upgrade from older CRDs
@@ -64,9 +67,12 @@ The upgrade procedure can be summarized by the following steps:
 4. Upgrade the CRDs
 
    ```
-   kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v5.0.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
-   kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v5.0.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
-   kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v5.0.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+   kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.3.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+   kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.3.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+   kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.3.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+   kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.3.0/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
+   kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.3.0/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
+   kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.3.0/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
    ```
 
 5. Upgrade to the latest version:

--- a/charts/snapshot-controller/templates/NOTES.txt
+++ b/charts/snapshot-controller/templates/NOTES.txt
@@ -2,7 +2,7 @@
 Volume Snapshot Controller installed.
 {{- end }}
 
-{{- if and (not (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1")) (not (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1beta") ) }}
+{{- if and (not (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1")) (not (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1beta1") ) }}
 Please install the snapshot CRDs, otherwise the controller will not run.
 
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/{{ .Chart.AppVersion }}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
@@ -15,6 +15,9 @@ you have the latest CRDs applied, you can run the following commands:
 kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/{{ .Chart.AppVersion }}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
 kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/{{ .Chart.AppVersion }}/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
 kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/{{ .Chart.AppVersion }}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/{{ .Chart.AppVersion }}/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
+kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/{{ .Chart.AppVersion }}/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
+kubectl replace -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/{{ .Chart.AppVersion }}/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
 {{- end }}
 
 If you already have volume snapshots deployed using a CRDs before v1, you should

--- a/charts/snapshot-controller/templates/volumegroupsnapshotclass.yaml
+++ b/charts/snapshot-controller/templates/volumegroupsnapshotclass.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.controller.enabled }}
+{{- range .Values.controller.volumeGroupSnapshotClasses }}
+---
+kind: VolumeGroupSnapshotClass
+apiVersion: groupsnapshot.storage.k8s.io/v1beta1
+metadata:
+  name: {{ .name }}
+{{- with .annotations }}
+  annotations: {{- . | toYaml | trim | nindent 4 }}
+{{- end }}
+  labels:
+  {{- include "snapshot-controller.labels" $ | nindent 4 }}
+{{- with .labels }}
+  {{- . | toYaml | trim | nindent 4 }}
+{{- end }}
+driver: {{ .driver }}
+deletionPolicy: {{ .deletionPolicy }}
+{{- with .parameters }}
+parameters: {{- . | toYaml | trim | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/snapshot-controller/values.yaml
+++ b/charts/snapshot-controller/values.yaml
@@ -69,6 +69,15 @@ controller:
 #      driver: linstor.csi.linbit.com
 #      deletionPolicy: Delete
 
+  volumeGroupSnapshotClasses: []
+#    - name: linstor-csi-delete
+#      annotations:
+#        groupsnapshot.storage.kubernetes.io/is-default-class: "true"
+#      labels:
+#        velero.io/csi-volumegroupsnapshot-class: "true"
+#      driver: linstor.csi.linbit.com
+#      deletionPolicy: Delete
+
   priorityClassName: ""
     # Specifies wether a Priority Class should be attached to deployment pods
 


### PR DESCRIPTION
We now support VolumeGroupSnapshotClasses, so add them as resource to the charts.

Closes #63 