### PR TITLE
fix(linstor-scheduler): add KubeSchedulerConfiguration v1 support for Kubernetes 1.25+

### DIFF
--- a/charts/linstor-scheduler/templates/config.yaml
+++ b/charts/linstor-scheduler/templates/config.yaml
@@ -8,7 +8,9 @@ metadata:
 data:
 {{- if semverCompare ">= 1.22-0" (include "linstor-scheduler.kubeVersion" .) }}
   scheduler-config.yaml: |-
-{{- if semverCompare ">= 1.23-0" (include "linstor-scheduler.kubeVersion" .) }}
+{{- if semverCompare ">= 1.25-0" (include "linstor-scheduler.kubeVersion" .) }}
+      apiVersion: kubescheduler.config.k8s.io/v1
+{{- else if semverCompare ">= 1.23-0" (include "linstor-scheduler.kubeVersion" .) }}
       apiVersion: kubescheduler.config.k8s.io/v1beta3
 {{- else }}
       apiVersion: kubescheduler.config.k8s.io/v1beta2


### PR DESCRIPTION
link https://github.com/piraeusdatastore/linstor-scheduler-extender/pull/18

## Summary

- Add support for stable `kubescheduler.config.k8s.io/v1` API for Kubernetes 1.25+
- Fix scheduler failing on Kubernetes 1.27+ where v1beta3 was removed

## Problem

The scheduler fails to start on Kubernetes 1.27+ with error:
```
no kind "KubeSchedulerConfiguration" is registered for version "kubescheduler.config.k8s.io/v1beta3"
```

## Solution

Add version detection to use:
- `v1` for Kubernetes >= 1.25 (stable API)
- `v1beta3` for Kubernetes 1.23-1.24
- `v1beta2` for Kubernetes 1.22