### PR TITLE
feat(linstor-scheduler): add admission webhook support with cert-manager

### DIFF
--- a/charts/linstor-scheduler/templates/admission-deployment.yaml
+++ b/charts/linstor-scheduler/templates/admission-deployment.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.admission.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}-admission
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admission
+spec:
+  replicas: {{ .Values.admission.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "linstor-scheduler.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: admission
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "linstor-scheduler.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: admission
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "linstor-scheduler.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: linstor-scheduler-admission
+          image: {{ .Values.extender.image.repository }}:{{ .Values.extender.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.extender.image.pullPolicy }}
+          command: ["/linstor-scheduler-admission"]
+          args:
+            - -scheduler={{ include "linstor-scheduler.fullname" . }}
+            - -tls-cert-file=/etc/webhook/certs/tls.crt
+            - -tls-key-file=/etc/webhook/certs/tls.key
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          ports:
+            - containerPort: 8080
+              name: https
+              protocol: TCP
+          env:
+            - name: LS_CONTROLLERS
+              value: {{ include "linstor-scheduler.linstorEndpoint" . }}
+            {{- if include "linstor-scheduler.linstorClientSecretName" . }}
+            - name: LS_USER_CERTIFICATE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "linstor-scheduler.linstorClientSecretName" . }}
+                  key: tls.crt
+            - name: LS_USER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "linstor-scheduler.linstorClientSecretName" . }}
+                  key: tls.key
+            - name: LS_ROOT_CA
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "linstor-scheduler.linstorClientSecretName" . }}
+                  key: ca.crt
+            {{- end }}
+          volumeMounts:
+            - name: webhook-certs
+              mountPath: /etc/webhook/certs
+              readOnly: true
+          resources:
+            {{- toYaml .Values.admission.resources | nindent 12 }}
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: {{ include "linstor-scheduler.fullname" . }}-admission-tls
+            defaultMode: 0400
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/linstor-scheduler/templates/admission-service.yaml
+++ b/charts/linstor-scheduler/templates/admission-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.admission.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}-admission
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admission
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      targetPort: 8080
+      protocol: TCP
+      name: https
+  selector:
+    {{- include "linstor-scheduler.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: admission
+{{- end }}

--- a/charts/linstor-scheduler/templates/certmanager.yaml
+++ b/charts/linstor-scheduler/templates/certmanager.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.admission.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}-admission-selfsigned
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}-admission-root-ca
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "linstor-scheduler.fullname" . }}-admission-root-ca
+  duration: 43800h  # 5 years
+  commonName: {{ include "linstor-scheduler.fullname" . }}-admission-root-ca
+  issuerRef:
+    name: {{ include "linstor-scheduler.fullname" . }}-admission-selfsigned
+  isCA: true
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}-admission-ca-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: {{ include "linstor-scheduler.fullname" . }}-admission-root-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}-admission-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "linstor-scheduler.fullname" . }}-admission-tls
+  duration: 8760h  # 1 year
+  renewBefore: 24h
+  issuerRef:
+    name: {{ include "linstor-scheduler.fullname" . }}-admission-ca-issuer
+  commonName: {{ include "linstor-scheduler.fullname" . }}-admission
+  dnsNames:
+    - {{ include "linstor-scheduler.fullname" . }}-admission
+    - {{ include "linstor-scheduler.fullname" . }}-admission.{{ .Release.Namespace }}.svc
+{{- end }}

--- a/charts/linstor-scheduler/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/linstor-scheduler/templates/mutatingwebhookconfiguration.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.admission.enabled }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}-admission
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "linstor-scheduler.fullname" . }}-admission-cert
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+webhooks:
+  - name: linstor-scheduler-admission.linbit.com
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    failurePolicy: {{ .Values.admission.failurePolicy }}
+    clientConfig:
+      service:
+        name: {{ include "linstor-scheduler.fullname" . }}-admission
+        namespace: {{ .Release.Namespace }}
+        path: /mutate
+        port: 443
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+        scope: "*"
+    {{- with .Values.admission.namespaceSelector }}
+    namespaceSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end }}

--- a/charts/linstor-scheduler/templates/rbac.yaml
+++ b/charts/linstor-scheduler/templates/rbac.yaml
@@ -24,6 +24,33 @@ rules:
       - list
       - watch
 {{- end }}
+{{- if .Values.admission.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}-admission
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "persistentvolumeclaims", "persistentvolumes"]
+    verbs: ["get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}-admission
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "linstor-scheduler.fullname" . }}-admission
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "linstor-scheduler.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/linstor-scheduler/values.yaml
+++ b/charts/linstor-scheduler/values.yaml
@@ -86,3 +86,21 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+admission:
+  enabled: false
+  replicaCount: 2
+  failurePolicy: Ignore
+  namespaceSelector: {}
+  #  matchExpressions:
+  #    - key: kubernetes.io/metadata.name
+  #      operator: NotIn
+  #      values:
+  #        - kube-system
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 10m
+    #   memory: 64Mi


### PR DESCRIPTION
## Summary

- Add optional MutatingWebhookConfiguration to automatically set schedulerName on pods that use LINSTOR-backed PVCs
- Use cert-manager for TLS certificate generation instead of init jobs

## Components

- `certmanager.yaml` - Issuer and Certificate resources for TLS
- `admission-deployment.yaml` - Webhook deployment (2 replicas by default)
- `admission-service.yaml` - ClusterIP service for webhook
- `mutatingwebhookconfiguration.yaml` - Webhook config with cert-manager CA injection
- Updated `rbac.yaml` - ClusterRole for reading pods, PVCs, PVs, storageclasses
- Updated `values.yaml` - New `admission` section

## Usage

The admission webhook is disabled by default. Enable it with:

```yaml
admission:
  enabled: true
```

## Requirements

- cert-manager must be installed in the cluster