### PR TITLE
fix(linstor-scheduler): fix chart template issues

### DIFF
--- a/charts/linstor-scheduler/templates/config.yaml
+++ b/charts/linstor-scheduler/templates/config.yaml
@@ -22,7 +22,7 @@ data:
           prioritizeVerb: prioritize
           weight: 5
           enableHTTPS: false
-          httpTimeout: 300000s
+          httpTimeout: 10s
           nodeCacheCapable: false
 {{- else }}
   policy.cfg: |-

--- a/charts/linstor-scheduler/templates/deployment.yaml
+++ b/charts/linstor-scheduler/templates/deployment.yaml
@@ -112,10 +112,6 @@ spec:
             name: {{ include "linstor-scheduler.fullname" . }}
           name: scheduler-config
       {{- end }}
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/linstor-scheduler/templates/poddisruptionbudget.yaml
+++ b/charts/linstor-scheduler/templates/poddisruptionbudget.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "linstor-scheduler.labels" . | nindent 6 }}
+      {{- include "linstor-scheduler.selectorLabels" . | nindent 6 }}
   {{- if .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- end }}


### PR DESCRIPTION
## Summary

Fix several issues in the linstor-scheduler chart templates.

## Changes

- Fix PodDisruptionBudget selector to use `selectorLabels` instead of full `labels` (was causing PDB to not match pods)
- Remove duplicate `imagePullSecrets` block in deployment template
- Reduce `httpTimeout` from 300000s (~83 hours) to 10s to prevent pods getting stuck in pending state when extender is unresponsive