### PR TITLE
fix: add missing default controller.fullnameOverride value for snapshot-controller

### DIFF
--- a/charts/snapshot-controller/values.yaml
+++ b/charts/snapshot-controller/values.yaml
@@ -5,6 +5,8 @@ controller:
 
   revisionHistoryLimit: 10
 
+  fullnameOverride: ""
+
   args:
     leaderElection: true
     leaderElectionNamespace: "$(NAMESPACE)"


### PR DESCRIPTION
`controller.fullnameOverride` is missing from chart's defaults