### PR TITLE
Add missing namespace values

### DIFF
--- a/charts/snapshot-controller/templates/crds.yaml
+++ b/charts/snapshot-controller/templates/crds.yaml
@@ -9,6 +9,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "conversion-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "conversion-webhook.labels" . | nindent 4 }}
 spec:
@@ -36,6 +37,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "conversion-webhook.certifcateName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "conversion-webhook.labels" . | nindent 4 }}
 type: kubernetes.io/tls


### PR DESCRIPTION
This pull request adds missing `namespace: {{ .Release.Namespace }}`. Important for Helm template in Terraform/ArgoCD. Else they get deployed in the `default` namespace.

See: https://github.com/helm/helm/issues/3553#issuecomment-2235841549