### PR TITLE
linstor-affinity-controller: mark as deprecated

### DIFF
--- a/charts/linstor-affinity-controller/Chart.yaml
+++ b/charts/linstor-affinity-controller/Chart.yaml
@@ -14,5 +14,6 @@ home: https://github.com/piraeusdatastore/helm-charts
 sources:
   - https://github.com/piraeusdatastore/linstor-affinity-controller
 
-version: 1.5.0
-appVersion: "v1.2.0"
+deprecated: true
+version: 1.6.0
+appVersion: "v1.4.0"

--- a/charts/linstor-affinity-controller/README.md
+++ b/charts/linstor-affinity-controller/README.md
@@ -1,5 +1,11 @@
 # LINSTOR Affinity Controller
 
+> [!IMPORTANT]
+> The LINSTOR Affinity Controller is deployed as part of, and does not need to be deployed separately
+> when using [Piraeus Operator].
+
+[Piraeus Operator]: https://piraeus.io/docs/
+
 The LINSTOR Affinity Controller keeps the affinity of your volumes in sync between Kubernetes and LINSTOR.
 
 Affinity is used by Kubernetes to track on which node a specific resource can be accessed. For example, you can use


### PR DESCRIPTION
The controller is now managed by the Operator.