### PR TITLE
linstor-scheduler: bump to chart 0.2.4 / appVersion v0.3.4

### DIFF
--- a/charts/linstor-scheduler/Chart.yaml
+++ b/charts/linstor-scheduler/Chart.yaml
@@ -16,6 +16,6 @@ home: https://github.com/piraeusdatastore/helm-charts
 sources:
   - https://github.com/piraeusdatastore/linstor-scheduler-extender
 
-version: 0.2.3
-appVersion: "v0.3.2"
+version: 0.2.4
+appVersion: "v0.3.4"
 deprecated: true


### PR DESCRIPTION
## Summary
- Bumps `linstor-scheduler` chart from `0.2.3` to `0.2.4`.
- Updates `appVersion` from `v0.3.2` to `v0.3.4` to pick up the latest [`linstor-scheduler-extender` release](https://github.com/piraeusdatastore/linstor-scheduler-extender/releases/tag/v0.3.4), which includes the changes merged via [PR #21](https://github.com/piraeusdatastore/linstor-scheduler-extender/pull/21).

The chart remains marked `deprecated: true`; this change is purely a version refresh so downstreams pulling from this chart repo can consume the newer extender release without overriding `extender.image.tag` manually.

## Test plan
- [ ] `helm lint charts/linstor-scheduler`
- [ ] Release workflow publishes `linstor-scheduler-0.2.4.tgz` after merge.