### PR TITLE
fix(snapshot-controller): inject conversion webhook for v8.6.0 CRDs

### DIFF
--- a/charts/snapshot-controller/Chart.yaml
+++ b/charts/snapshot-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: snapshot-controller
-version: 5.1.0
+version: 5.1.1
 appVersion: "v8.6.0"
 kubeVersion: ">= 1.25.0-0"
 icon: https://raw.githubusercontent.com/piraeusdatastore/piraeus/master/artwork/sandbox-artwork/icon/color.svg

--- a/charts/snapshot-controller/Makefile
+++ b/charts/snapshot-controller/Makefile
@@ -12,8 +12,8 @@ crds:
 		curl -fsSL https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/$(APP_VERSION)/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml ;\
 		curl -fsSL https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/$(APP_VERSION)/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml ;\
 		curl -fsSL https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/$(APP_VERSION)/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml \
-	) | yq 'select(.spec.conversion).spec.conversion.webhook.clientConfig = "{{ toJson .ClientConfig }}"' \
-	  | yq 'select(.spec.conversion).metadata.annotations["cert-manager.io/inject-ca-from"] = "{{ .InsertCaFrom }}"' \
+	) | yq '(select(.metadata.name == "volumegroupsnapshotcontents.groupsnapshot.storage.k8s.io") | .spec.conversion) = {"strategy": "Webhook", "webhook": {"conversionReviewVersions": ["v1"], "clientConfig": "{{ toJson .ClientConfig }}"}}' \
+	  | yq '(select(.metadata.name == "volumegroupsnapshotcontents.groupsnapshot.storage.k8s.io") | .metadata.annotations["cert-manager.io/inject-ca-from"]) = "{{ .InsertCaFrom }}"' \
 	  | sed -e "s/'{{ toJson .ClientConfig }}'/{{ toJson .ClientConfig }}/" \
 	  | sed -e "s#\(cert-manager.io/inject-ca-from.*\)#{{ if .InsertCaFrom }}cert-manager.io/inject-ca-from: '{{ .InsertCaFrom }}'{{ end }}#" \
 	  > crds.yaml


### PR DESCRIPTION
## Problem

Fixes #87.

`snapshot-controller` 5.1.0 (appVersion `v8.6.0`) generates an invalid
`volumegroupsnapshotcontents.groupsnapshot.storage.k8s.io` CRD. The API server
rejects it (most visibly under server-side apply, e.g. ArgoCD):

```
CustomResourceDefinition "volumegroupsnapshotcontents.groupsnapshot.storage.k8s.io" is invalid:
[spec.conversion.strategy: Required value,
 spec.conversion.webhookClientConfig: Forbidden: should not be set when strategy is not set to Webhook]
```

## Root cause

`make crds` injects the webhook `clientConfig` only into CRDs that **already**
carry `.spec.conversion`:

```make
| yq 'select(.spec.conversion).spec.conversion.webhook.clientConfig = "{{ toJson .ClientConfig }}"'
```

external-snapshotter **v8.6.0 removed the inline `conversion:` stanza** from
`groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml` (part of the
VolumeGroupSnapshot GA promotion, which also added a served `v1`). With no
pre-existing `.spec.conversion`, `select(.spec.conversion)` matches nothing, so
the webhook block is never injected — producing a multi-version CRD (`v1`,
`v1beta1`, `v1beta2`) with no conversion strategy.

| external-snapshotter | vgsc inline `conversion` | versions |
|---|---|---|
| v8.5.0 | present (`strategy: Webhook`) | v1beta1, v1beta2 |
| v8.6.0 | **absent** | v1, v1beta1, v1beta2 |

## Fix

Set the conversion webhook **explicitly** on `volumegroupsnapshotcontents` (the
only CRD that needs it — its v1beta1/v1beta2 schemas differ, and the
conversion-webhook Deployment is still shipped/required) instead of gating on a
pre-existing `.spec.conversion`:

```make
| yq '(select(.metadata.name == "volumegroupsnapshotcontents.groupsnapshot.storage.k8s.io") | .spec.conversion) = {"strategy": "Webhook", "webhook": {"conversionReviewVersions": ["v1"], "clientConfig": "{{ toJson .ClientConfig }}"}}' \
| yq '(select(.metadata.name == "volumegroupsnapshotcontents.groupsnapshot.storage.k8s.io") | .metadata.annotations["cert-manager.io/inject-ca-from"]) = "{{ .InsertCaFrom }}"' \
```

This regenerates the same `conversion: {strategy: Webhook, ...}` block that 5.0.4
(v8.5.0) shipped.

## Verification

- `make crds` against `appVersion v8.6.0` now emits exactly one
  `strategy: Webhook` block (on `volumegroupsnapshotcontents`), with the
  `{{ toJson .ClientConfig }}` placeholder preserved.
- `helm template` renders the CRD with a populated `clientConfig`.
- `kubectl apply --server-side --dry-run=server` of the rendered CRD succeeds
  against a cluster currently running the v8.5.0 CRD (it reproduces the exact
  error from #87 with the 5.1.0 output).

Chart version bumped `5.1.0` → `5.1.1`.
