### PR TITLE
linstor-scheduler: bump to chart 0.3.1 / appVersion v0.3.6

### DIFF
--- a/charts/linstor-scheduler/Chart.yaml
+++ b/charts/linstor-scheduler/Chart.yaml
@@ -16,6 +16,6 @@ home: https://github.com/piraeusdatastore/helm-charts
 sources:
   - https://github.com/piraeusdatastore/linstor-scheduler-extender
 
-version: 0.3.0
-appVersion: "v0.3.5"
+version: 0.3.1
+appVersion: "v0.3.6"
 deprecated: true


### PR DESCRIPTION
Bump the `linstor-scheduler` chart to `appVersion: v0.3.6` (chart `0.3.1`).

v0.3.6 carries the admission webhook TLS certificate hot-reload fix (piraeusdatastore/linstor-scheduler-extender#22): the webhook loaded its certificate once at startup, so after the mounted Secret was rotated it kept serving the old leaf certificate and, with `failurePolicy: Ignore`, silently stopped assigning the scheduler until it was restarted. v0.3.6 reloads the certificate on rotation, so the admission webhook no longer needs an external cert-reload workaround.
