### PR TITLE
fix(snapshot-controller): disable webhook by default

### DIFF
--- a/charts/snapshot-controller/Chart.yaml
+++ b/charts/snapshot-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: snapshot-controller
-version: 5.1.1
+version: 5.2.0
 appVersion: "v8.6.0"
 kubeVersion: ">= 1.25.0-0"
 icon: https://raw.githubusercontent.com/piraeusdatastore/piraeus/master/artwork/sandbox-artwork/icon/color.svg

--- a/charts/snapshot-controller/Makefile
+++ b/charts/snapshot-controller/Makefile
@@ -16,4 +16,6 @@ crds:
 	  | yq '(select(.metadata.name == "volumegroupsnapshotcontents.groupsnapshot.storage.k8s.io") | .metadata.annotations["cert-manager.io/inject-ca-from"]) = "{{ .InsertCaFrom }}"' \
 	  | sed -e "s/'{{ toJson .ClientConfig }}'/{{ toJson .ClientConfig }}/" \
 	  | sed -e "s#\(cert-manager.io/inject-ca-from.*\)#{{ if .InsertCaFrom }}cert-manager.io/inject-ca-from: '{{ .InsertCaFrom }}'{{ end }}#" \
+	  | sed -e 's#^  conversion:$$#{{- if .WebhookEnabled }}\n  conversion:#' \
+	  | sed -e 's#^      clientConfig: {{ toJson .ClientConfig }}$$#      clientConfig: {{ toJson .ClientConfig }}\n{{- end }}#' \
 	  > crds.yaml

--- a/charts/snapshot-controller/README.md
+++ b/charts/snapshot-controller/README.md
@@ -60,8 +60,10 @@ helm upgrade snapshot-controller piraeus-charts/snapshot-controller
 The following changes have been made when moving to Chart v5.0.0+:
 
 * CRDs are deployed as part of the regular resource. Installation can be controlled using the `installCRDs` value.
-* The Snapshot Conversion Webhook is deployed by default to convert Volume Group Snapshot Content between v1beta1 and
-  v1beta2.
+* The Snapshot Conversion Webhook can be deployed to convert Volume Group Snapshot Content between v1beta1 and
+  v1beta2. It is disabled by default; enable it with `webhook.enabled=true` only if your cluster still holds group
+  snapshot objects in those older API versions. When disabled, no conversion strategy is injected into the
+  volumegroupsnapshotcontents CRD (it defaults to `None`, matching upstream).
 * `volumeSnapshotClasses` and `volumeGroupSnapshotClasses` have been moved from `controller` to the top of the values.
 
 Upgrades may fail to apply because of the changed deployment strategy for CRDs with an error such as:
@@ -124,7 +126,7 @@ The following options are available:
 | `controller.hostNetwork`               | Change `hostNetwork` to `true` when you want the pod to share its host's network namespace.                                    | `false`                                                                                            |
 | `controller.dnsConfig`                 | DNS settings for controller pod.                                                                                               | `{}`                                                                                               |
 | `controller.dnsPolicy`                 | DNS Policy for controller pod. For Pods running with hostNetwork, set to `ClusterFirstWithHostNet`.                            | `ClusterFirst`                                                                                     |
-| `webhook.enabled`                      | Toggle to disable the deployment of the snapshot controller.                                                                   | `true`                                                                                             |
+| `webhook.enabled`                      | Deploy the conversion webhook and inject the `Webhook` conversion strategy into the volumegroupsnapshotcontents CRD. Only needed for clusters still holding v1beta1/v1beta2 group snapshot objects. | `false`                                                            |
 | `webhook.fullnameOverride`             | Set the base name of deployed resources. Defaults to `snapshot-controller-conversion-webhook`.                                 | `""`                                                                                               |
 | `webhook.args`                         | Arguments to pass to the snapshot conversion webhook. Note: Keys will be converted to kebab-case, i.e. `oneArg` -> `--one-arg` | `...`                                                                                              |
 | `webhook.tls.certificateSecret`        | Name of the certificate secret to use for serving TLS.                                                                         | `""`                                                                                               |

--- a/charts/snapshot-controller/templates/crds.yaml
+++ b/charts/snapshot-controller/templates/crds.yaml
@@ -3,6 +3,7 @@
 {{ $ca := "" }}
 {{ $key := "" }}
 {{ $crt := "" }}
+{{- if .Values.webhook.enabled }}
 {{- if .Values.webhook.tls.certManagerIssuerRef }}
 ---
 apiVersion: cert-manager.io/v1
@@ -50,15 +51,16 @@ data:
   tls.key: {{ $key }}
   tls.crt: {{ $crt }}
 {{- end }}
+{{- end }}
 ---
 {{- if .Values.installCRDs }}
 {{- $insertCaFrom := "" }}
-{{- if .Values.webhook.tls.certManagerIssuerRef }}
+{{- if and .Values.webhook.enabled .Values.webhook.tls.certManagerIssuerRef }}
 {{- $insertCaFrom = printf "%s/%s" .Release.Namespace (include "conversion-webhook.certifcateName" .) }}
 {{- end }}
 {{- $clientConfig := dict "service" (dict "namespace" .Release.Namespace "name" (include "conversion-webhook.fullname" .) "path" "/convert") }}
 {{- if $ca }}
 {{- $clientConfig = set $clientConfig "caBundle" $ca }}
 {{- end }}
-{{ tpl (.Files.Get "crds.yaml") (dict "ClientConfig" $clientConfig "InsertCaFrom" $insertCaFrom) }}
+{{ tpl (.Files.Get "crds.yaml") (dict "ClientConfig" $clientConfig "InsertCaFrom" $insertCaFrom "WebhookEnabled" .Values.webhook.enabled) }}
 {{- end }}

--- a/charts/snapshot-controller/values.yaml
+++ b/charts/snapshot-controller/values.yaml
@@ -78,7 +78,11 @@ controller:
   dnsPolicy: ClusterFirst
 
 webhook:
-  enabled: true
+  # The conversion webhook is only needed for clusters that still hold VolumeGroupSnapshot
+  # objects in the v1beta1/v1beta2 API versions. When disabled, the conversion strategy is
+  # not injected into the volumegroupsnapshotcontents CRD (it defaults to `None`, matching
+  # upstream). Enable this only if you rely on the older group snapshot API versions.
+  enabled: false
 
   replicaCount: 1
 


### PR DESCRIPTION
The conversion webhook shipped with external-snapshotter v8.6.0 only converts between v1beta1 and v1beta2, but the v8.6.0 controller writes group snapshot contents at v1. Injecting conversion.strategy: Webhook into the volumegroupsnapshotcontents CRD therefore breaks every group snapshot operation, since nothing in the release can perform the required v1 conversion.

Default webhook.enabled to false and only inject the conversion stanza (and create the TLS Secret / cert-manager Certificate) when the webhook is explicitly enabled.

Fixes #98 